### PR TITLE
Fix incorrect help string for helm commands

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -7,7 +7,8 @@ import (
 // helmCmd represents the helm command
 var helmCmd = &cobra.Command{
 	Use:   "helm",
-	Short: "Run kubebox for the given cluster",
+	Short: "Run a helm command against the given cluster",
+	Long: "Helm is a package manager for Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
 		RunBinary("helm", ClusterID, args)
 	},


### PR DESCRIPTION
Looks like it was a bad paste from the kubebox cmd.